### PR TITLE
fix: improve mobile view layout for Experience, Projects, and Blogs s…

### DIFF
--- a/src/components/Blogs.tsx
+++ b/src/components/Blogs.tsx
@@ -60,10 +60,10 @@ function Blogs() {
               )}
             </div>
             <div className="block mt-3">
-              <div className="text-base text-lightPrimaryAccent dark:text-primary font-black h-blogHeight">
+              <div className="text-base text-lightPrimaryAccent dark:text-primary font-black lg:h-blogHeight">
                 {ele.name}
               </div>
-              <div className="text-lightSubtext dark:text-secondColor font-bold text-sm h-blogheight overflow-scroll mt-2">
+              <div className="text-lightSubtext dark:text-secondColor font-bold text-sm lg:h-blogheight lg:overflow-scroll mt-2">
                 {ele.subject}
               </div>
             </div>

--- a/src/components/MainProject.tsx
+++ b/src/components/MainProject.tsx
@@ -106,11 +106,11 @@ const MainProject = () => {
 
                     {/* Highlights — shown on hover/always on mobile */}
                     <div
-                      className={`mt-3 space-y-1.5 transition-all duration-300 overflow-hidden ${
+                      className={`mt-3 space-y-1.5 transition-all duration-300 overflow-hidden max-h-0 opacity-0 ${
                         hoveredId === project.id
-                          ? "max-h-40 opacity-100"
-                          : "max-h-0 opacity-0 lg:max-h-0 lg:opacity-0"
-                      } max-h-40 opacity-100 sm:max-h-40 sm:opacity-100 lg:max-h-0 lg:opacity-0`}
+                          ? "lg:max-h-40 lg:opacity-100"
+                          : "lg:max-h-0 lg:opacity-0"
+                      }`}
                       style={
                         hoveredId === project.id
                           ? { maxHeight: "160px", opacity: 1 }

--- a/src/components/Work.tsx
+++ b/src/components/Work.tsx
@@ -133,13 +133,11 @@ const Work = () => {
     },
   ];
 
+  const isMobile = typeof window !== "undefined" && window.innerWidth < 1024;
   const [expandedCompanies, setExpandedCompanies] = useState([1, 2, 3]);
-  const [expandedRoles, setExpandedRoles] = useState([
-    "et-sde",
-    "et-intern",
-    "noggin-intern",
-    "wc-intern",
-  ]);
+  const [expandedRoles, setExpandedRoles] = useState<string[]>(
+    isMobile ? [] : ["et-sde", "et-intern", "noggin-intern", "wc-intern"],
+  );
 
   const toggleCompanyExpand = (id: number) => {
     setExpandedCompanies((prev) =>
@@ -267,7 +265,7 @@ const Work = () => {
                           {expandedCompanies.includes(company.id) &&
                             expandedRoles.includes(role.id) && (
                               <div className="mt-3">
-                                <ul className="space-y-4">
+                                <ul className="space-y-2 lg:space-y-4">
                                   {role.workDone.map((item, index) => (
                                     <li
                                       key={index}


### PR DESCRIPTION
…ections

- Work: collapse role details by default on mobile, expand on desktop
- Work: reduce bullet point spacing on mobile (space-y-2 vs space-y-4)
- MainProject: hide highlights on mobile (hover-only for lg+)
- Blogs: remove fixed heights on mobile to prevent title/description overlap